### PR TITLE
Add retry to dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120
+
           vulnerability-check: true
           fail-on-severity: moderate
 


### PR DESCRIPTION
### Description
https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#using-github-actions-to-access-the-dependency-submission-api-and-the-dependency-review-api

For retry value, used the default specified in https://github.com/actions/dependency-review-action?tab=readme-ov-file#configuration-options

### Testing
