### PR TITLE
Dependency Review: re-enable comments and increase timeout

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           retry-on-snapshot-warnings: true
-          retry-on-snapshot-warnings-timeout: 120
+          retry-on-snapshot-warnings-timeout: 900
 
           vulnerability-check: true
           fail-on-severity: moderate
@@ -32,6 +32,6 @@ jobs:
             Unlicense,
             CC0-1.0
 
-          #comment-summary-in-pr: on-failure
+          comment-summary-in-pr: on-failure
 
           warn-only: true


### PR DESCRIPTION
### Description
1. Update timeout to 15 minutes. This is shorter than the overall build time, which can be 20-30 minutes. This is needed because sometimes it takes longer for `master`'s Dependency Submission Action run to queue, execute, upload, and complete.
2. Re-enabled comments. It appears the initial FP's were due to a race condition, where some PR's Dependency Review ran before `master`'s ran.


### Testing
