### PR TITLE
Disable PR comments, wait for eng to fork from fresh master

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -32,6 +32,6 @@ jobs:
             Unlicense,
             CC0-1.0
 
-          comment-summary-in-pr: on-failure
+          # comment-summary-in-pr: on-failure
 
           warn-only: true


### PR DESCRIPTION
### Description
Some PRs received unexpected alerts. Those alerts reported all the Java dependencies as new ones.

Turns out that older master commits do not have Dependency Submission snapshots, so diff’ing against them reported unexpected new dependencies. 

Disabling comments for now, while we wait for most/all engineers to fork from a master commit newer than [Apr 8, 2025 1pm CT](https://github.com/hex-inc/hex/pull/30870).

### Testing
