### PR TITLE
trigger on label

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,11 @@
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description
The Dependency Review action fails to trigger sometimes. As a workaround, we're making it trigger on label/unlabel. See https://hex-tech-hq.slack.com/archives/C05AYKDRT6H/p1744922860512639

### Testing
