### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,6 +1,8 @@
 ---
 name: YAML Lint
 on: [push]
+permissions:
+  contents: read
 jobs:
   lint-yaml:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hex-inc/shared-workflows/security/code-scanning/1](https://github.com/hex-inc/shared-workflows/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs a linting operation, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow operates with the least privileges necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
