### PR TITLE
Add public domain license to allowlist

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -42,6 +42,7 @@ jobs:
             CC0-1.0,
             EPL-2.0,
             ISC,
+            LicenseRef-scancode-public-domain,
             MIT,
             MIT-0,
             MPL-2.0,
@@ -65,5 +66,3 @@ jobs:
             pkg:npm/%2540lancedb/lancedb-win32-x64-msvc
 
           comment-summary-in-pr: on-failure
-
-          warn-only: true


### PR DESCRIPTION
### Description

* Add `LicenseRef-scancode-public-domain` (public domain) to approved licenses
* Enforce dependency review check (instead of just warning) now that we know it's reasonably working

### Testing

Doing it live.