### PR TITLE
dependency-review: Set `base-ref` and `head-ref` to cascading values

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
+          base-ref: >
+            ${{
+              github.event_name == 'pull_request' && github.event.pull_request.base.sha ||
+              github.event_name == 'merge_group' && github.event.merge_group.base_sha ||
+              github.event.repository.default_branch
+            }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 900
 

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120


### PR DESCRIPTION
### Description

Depending on how the commit is done, it may be difficult for dependency-review to properly calculate the right `base-ref` / `head-ref` values, so set some defaults to account for common issues.

### Testing

Will test on a new PR.