### PR TITLE
Move comments out of block to fix YAML syntax error

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -60,9 +60,11 @@ jobs:
             WTFPL,
             Zlib
 
+          # npm/@lancedb/lancedb*: Temporary addition due to upstream non-compliance with SPDX
+          #                        (https://github.com/lancedb/lancedb/pull/2558)
+          # npm/cookie-signature: Temporary addition due to ClearlyDefined error
+          #                       (https://github.com/clearlydefined/curated-data/pull/29904)
           allow-dependencies-licenses: >-
-            # Temporary addition due to upstream non-compliance with SPDX
-            # https://github.com/lancedb/lancedb/pull/2558
             pkg:npm/%2540lancedb/lancedb,
             pkg:npm/%2540lancedb/lancedb-darwin-arm64,
             pkg:npm/%2540lancedb/lancedb-darwin-x64,
@@ -72,8 +74,6 @@ jobs:
             pkg:npm/%2540lancedb/lancedb-linux-x64-musl,
             pkg:npm/%2540lancedb/lancedb-win32-arm64-msvc,
             pkg:npm/%2540lancedb/lancedb-win32-x64-msvc,
-            # Temporary addition due to ClearlyDefined error
-            # https://github.com/clearlydefined/curated-data/pull/29904
             pkg:npm/cookie-signature
 
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
### Description

YAML doesn't like comments in the middle of other values, so remove the comments outside of the block

### Testing

Testing it live.