### PR TITLE
Allowlist ag grid deps

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -75,5 +75,6 @@ jobs:
             pkg:npm/%2540lancedb/lancedb-win32-arm64-msvc,
             pkg:npm/%2540lancedb/lancedb-win32-x64-msvc,
             pkg:npm/cookie-signature
+            pkg:npm/%2540ag-grid-enterprise
 
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -74,7 +74,7 @@ jobs:
             pkg:npm/%2540lancedb/lancedb-linux-x64-musl,
             pkg:npm/%2540lancedb/lancedb-win32-arm64-msvc,
             pkg:npm/%2540lancedb/lancedb-win32-x64-msvc,
-            pkg:npm/cookie-signature
+            pkg:npm/cookie-signature,
             pkg:npm/%2540ag-grid-enterprise
 
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
### Description

See failure here: https://github.com/hex-inc/hex/actions/runs/17751373851?pr=35367

Ag grid uses an odd license but we pay to use them so should be okay
