### PR TITLE
Reduce timeout on Dependency Review snapshots

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
             }}
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
           retry-on-snapshot-warnings: true
-          retry-on-snapshot-warnings-timeout: 420
+          retry-on-snapshot-warnings-timeout: 480
 
           vulnerability-check: true
           fail-on-severity: moderate

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
             }}
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
           retry-on-snapshot-warnings: true
-          retry-on-snapshot-warnings-timeout: 900
+          retry-on-snapshot-warnings-timeout: 420
 
           vulnerability-check: true
           fail-on-severity: moderate


### PR DESCRIPTION
### Description

Reducing timeout from 15 to 8 minutes.

1. The [Gradle Dependency Submission](https://github.com/hex-inc/hex/actions/workflows/gradle-dependency-submission.yml) action takes less than 1 minute 30 seconds.
2. The [retry](https://github.com/hex-inc/hex/actions/workflows/rerun-dep-submissions.yml) action for Gradle Dependency Submission runs every 5 minutes.
3. So 1:30m potential failed run + 5m wait + 1:30 retry run == 8 minutes should be sufficient timeout to wait for Dependency Graph snapshots on base & head commits.