### PR TITLE
Manual dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,17 @@
+name: "Dependency Submission"
+on:
+  workflow_dispatch:
+  push:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+      - name: Component Detection
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1


### PR DESCRIPTION
### Description
Given that Github has stopped automatically submitting dependencies on our repos since March 23, 2026, we're adding an Action to do so manually. These dependency snapshots on every commit are required for Dependency Review to work. 

### Testing
