### PR TITLE
Dependency Review triggers

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Debug concurrency group
+        run: echo "${{ github.workflow }}-${{ github.repository }}-${{ github.event.number }}"
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Check for dependency file changes

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,13 +1,20 @@
 ---
 name: "Dependency Review"
-on: [pull_request]
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,6 @@
 ---
 name: "Dependency Review"
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - labeled
-      - unlabeled
+on: [pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,8 +21,6 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Debug concurrency group
-        run: echo "${{ github.workflow }}-${{ github.repository }}-${{ github.event.number }}"
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Check for dependency file changes


### PR DESCRIPTION
### Description

Occasionally the GH Action for Dependency Review stays stuck waiting for the workflow to kick off. That may be correlated to rebases (like changing the base to main), but unclear. Making the following changes as potential fixes.

1. Adding "concurrency" config to cancel older runs. Just in case we're triggering several runs, causing a backlog.
2. Adding "edited" event as trigger, to make sure we trigger on rebase.

### Testing
