### PR TITLE
Add license exception for the `@trpc` project

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -158,6 +158,8 @@ jobs:
           # pypi/pyzmq: LGPL-3.0-only AND LicenseRef-github-NOASSERTION -- only approving as a one-off
           # npm/glob: CC-BY-SA-4.0 -- A one-off bypass since we're not shipping code with it
           # npm/@cspell/dict-en-common-misspellings: LicenseRef-bad-cc-by-sa-4.0 -- Not shipping in code
+          # npm/@trpc/{server|client}: Temporary addition due to upstream non-compliance with SPDX
+          #                            The library defines an MIT license for the whole project.
           allow-dependencies-licenses: >-
             pkg:npm/@lancedb/lancedb,
             pkg:npm/@lancedb/lancedb-darwin-arm64,
@@ -194,6 +196,8 @@ jobs:
             pkg:pypi/pyzmq,
             pkg:npm/glob,
             pkg:npm/@cspell/dict-en-common-misspellings
+            pkg:npm/@trpc/server
+            pkg:npm/@trpc/client
 
           # Known vulnerabilities we're ok with ignoring.
           # These are generally because they are in an older python kernel

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -195,8 +195,8 @@ jobs:
             pkg:pypi/pylint,
             pkg:pypi/pyzmq,
             pkg:npm/glob,
-            pkg:npm/@cspell/dict-en-common-misspellings
-            pkg:npm/@trpc/server
+            pkg:npm/@cspell/dict-en-common-misspellings,
+            pkg:npm/@trpc/server,
             pkg:npm/@trpc/client
 
           # Known vulnerabilities we're ok with ignoring.


### PR DESCRIPTION
This is an MIT project but isn't being picked up correctly

- Root project license: https://github.com/trpc/trpc/blob/main/LICENSE
- Individual packages also declared as MIT:
     - server: https://github.com/trpc/trpc/blob/main/packages/server/package.json#L8
     - client: https://github.com/trpc/trpc/blob/main/packages/client/package.json#L7

