### PR TITLE
Update dependency review workflow with new GHSA IDs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -209,8 +209,12 @@ jobs:
           # unsupported by us).
           # filelock: https://github.com/advisories/GHSA-w853-jp5j-5j7f
           # filelock: https://github.com/advisories/GHSA-qmgc-5h2g-mvrw
+          # filelock: https://github.com/advisories/GHSA-5v7r-6r5c-r473
+          # filelock: https://github.com/advisories/GHSA-j47w-4g3g-c36v
           allow-ghsas: >-
             GHSA-w853-jp5j-5j7f,
-            GHSA-qmgc-5h2g-mvrw
+            GHSA-qmgc-5h2g-mvrw,
+            GHSA-5v7r-6r5c-r473,
+            GHSA-j47w-4g3g-c36v,
 
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
### Description

Related to https://github.com/hex-inc/hex/actions/runs/25819591849?pr=42889

swc/cli is only used as a dev dependency. Unfortunately just bumping swc/cli leads to another conflict on `chokidar` see https://github.com/hex-inc/hex/pull/42957.

Solvable but just a level of scope creep I can't sidequest for right now.

### Testing
