### PR TITLE
Bump `actions/dependency-review-action` to v5

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -90,7 +90,7 @@ jobs:
         if: >-
           steps.check-deps.outputs.deps_changed == 'true'
           && steps.check-revert.outputs.is_revert != 'true'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           base-ref: >
             ${{
@@ -104,6 +104,7 @@ jobs:
 
           vulnerability-check: true
           fail-on-severity: moderate
+          show-patched-versions: true
 
           license-check: true
           # comma-separated SPDX identifiers


### PR DESCRIPTION
### Description

Upstream `actions/dependency-review-action` released a new major version (v5), so bump the version we use.

https://github.com/actions/dependency-review-action/releases/tag/v5.0.0

### Testing

N/A