### PR TITLE
Add `Apache-1.1` as an approved license

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -113,6 +113,7 @@ jobs:
           allow-licenses: >-
             0BSD,
             AFL-2.1,
+            Apache-1.1,
             Apache-2.0,
             Artistic-2.0,
             BlueOak-1.0.0,


### PR DESCRIPTION
### Description

Add the `Apache-1.1` license as an approved open source license.

### Testing

N/A