### PR TITLE
Allow trove4j (LGPL-2.1) build-time transitive in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -164,6 +164,9 @@ jobs:
           #                 (https://github.com/pyramation/nested-obj/pull/1)
           # maven/com.google.errorprone/error_prone_annotations: Temporary addition due to ClearlyDefined error
           #       (https://github.com/clearlydefined/curated-data/pull/30203)
+          # maven/org.jetbrains.intellij.deps/trove4j: LGPL-2.1 -- build-time transitive of
+          #       kotlin-compiler-embeddable (the Kotlin Gradle plugin); not shipped in any
+          #       runtime artifact. Only approving as a one-off.
           # npm/canvas: Temporary addition due to ClearlyDefined error
           #             (https://github.com/clearlydefined/curated-data/pull/32066)
           # npm/bignumber.js: ClearlyDefined error showing inaccurate license
@@ -205,6 +208,7 @@ jobs:
             pkg:npm/nested-obj,
             pkg:pypi/charset-normalizer,
             pkg:maven/com.google.errorprone/error_prone_annotations,
+            pkg:maven/org.jetbrains.intellij.deps/trove4j,
             pkg:npm/canvas,
             pkg:npm/bignumber.js,
             pkg:pypi/chardet,


### PR DESCRIPTION
## What

Adds `pkg:maven/org.jetbrains.intellij.deps/trove4j` to `allow-dependencies-licenses` in the shared Dependency Review workflow.

## Why

Since hex-inc/hex#44899 (data-service split into `core` + `app` Gradle modules), the dependency-review check fails with:

```
data-service/settings.gradle.kts » org.jetbrains.intellij.deps:trove4j@1.0.20200330 – License: LGPL-2.1
❌ Dependency review detected incompatible licenses.
```

`trove4j` is JetBrains' fork of the GNU Trove primitive-collections library, carried as a **build-time transitive of `kotlin-compiler-embeddable`** (pulled in by the `kotlin("jvm")` Gradle plugin). It is used by the Kotlin compiler *while compiling* and is **not linked into or shipped in any runtime artifact** — so the LGPL-2.1 license (which also carries a linking exception) poses no distribution-licensing concern.

The module split changed the submitted Gradle dependency graph attribution (now under `data-service/settings.gradle.kts`), which surfaced `trove4j` into the diff and now fails every PR that touches the data-service build files.

## Precedent

This follows the existing one-off exemptions already in this list for build/dev-only copyleft deps that aren't shipped:

- `pkg:npm/@img/sharp-libvips-*` — LGPL-3.0-or-later, "only approving as a one-off; for local dev"
- `pkg:npm/glob` — CC-BY-SA-4.0, "one-off bypass since we're not shipping code with it"
- `pkg:pypi/{chardet,shapely,astroid,pylint,pyzmq,psycopg2}` — various LGPL/GPL one-offs
- `pkg:maven/com.google.errorprone/error_prone_annotations` — the existing maven exemption

## Sign-off

Per the header note in this file, this needs **legal/security approval**. This adds a single package to the per-dependency exception list (not a change to the global `allow-licenses` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)