### PR TITLE
dependency-review: allow com.mysql:mysql-connector-j (GPL-2.0 + Universal FOSS Exception)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -186,6 +186,14 @@ jobs:
           # npm/strtok3: MIT AND Ruby -- the Ruby License is OSI-approved and permissive
           #              (used by Ruby itself); MIT covers the strtok3 code. Approving as
           #              a one-off rather than adding Ruby to the global allow list.
+          # maven/com.mysql/mysql-connector-j: GPL-2.0 with the Universal FOSS Exception --
+          #              the MySQL Connector/J JDBC driver. This is the SAME license Hex has
+          #              long shipped via the legacy mysql:mysql-connector-java coordinate; the
+          #              only change is Oracle's Maven coordinate rename, required to clear HIGH
+          #              CVE-2023-22102 (no fix exists on the old coordinate). The driver is
+          #              loaded at arm's length inside the data-service (separate process, its
+          #              own isolated URLClassLoader, reached only over the JDBC API) -- not
+          #              statically linked into shipped code. Approving as a one-off. (NOVA-4748)
           allow-dependencies-licenses: >-
             pkg:npm/@lancedb/lancedb,
             pkg:npm/@lancedb/lancedb-darwin-arm64,
@@ -225,7 +233,8 @@ jobs:
             pkg:npm/@cspell/dict-en-common-misspellings,
             pkg:npm/@trpc/server,
             pkg:npm/@trpc/client,
-            pkg:npm/strtok3
+            pkg:npm/strtok3,
+            pkg:maven/com.mysql/mysql-connector-j
 
           # Known vulnerabilities we're ok with ignoring.
           # These are generally because they are in an older python kernel


### PR DESCRIPTION
## What

Adds `pkg:maven/com.mysql/mysql-connector-j` to `allow-dependencies-licenses` in the shared dependency-review workflow.

## Why

The `dependency-review` check is failing on **hex-inc/hex** PR [#44911](https://github.com/hex-inc/hex/pull/44911) (MySQL JDBC 8.0.27 → 8.4 dual-driver, NOVA-4748) with *"Dependency review detected incompatible licenses."*

The flagged package is `com.mysql:mysql-connector-j@8.4.0`, whose POM declares **"The GNU General Public License, v2 with Universal FOSS Exception, v1.0"** (normalized to `GPL-2.0`, which is not in the blanket `allow-licenses` list — correctly, since it's copyleft).

Key points for the reviewer:

- **Not new license exposure.** This is the *same* license Hex has shipped for years via the legacy `mysql:mysql-connector-java` coordinate. That coordinate was grandfathered into the baseline, so it was never license-reviewed. The check fires now only because Oracle **renamed the Maven coordinate** (`mysql:mysql-connector-java` → `com.mysql:mysql-connector-j` at 8.0.31), so it appears as a brand-new dependency in the diff.
- **The rename is required for the security fix.** HIGH-severity **CVE-2023-22102** has **no fix on the old coordinate** — it's only patched under the renamed `com.mysql:mysql-connector-j` artifact (≥ 8.2.0). So we cannot clear the CVE without moving coordinates.
- **Arm's-length usage.** The driver runs inside the `data-service` as a separate process, loaded in its own isolated `URLClassLoader` (the dual-driver adapter SPI), and is reached only through the standard JDBC API — it is not statically linked into shipped proprietary code.
- Precedent: `allow-dependencies-licenses` already carries copyleft one-offs (e.g. `pkg:pypi/pylint` = `GPL-2.0-only`, `pkg:maven/org.jetbrains.intellij.deps/trove4j` = LGPL).

## ⚠️ Approval required

Per the file's own guardrail (*"DO NOT ADD LICENSES WITHOUT APPROVAL FROM LEGAL/SECURITY"*), this needs **legal/security sign-off before merge**. Opening the PR as the vehicle for that review — please do not merge until approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)