### PR TITLE
Deprecate vuln checks by `Dependency Review`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -102,9 +102,7 @@ jobs:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 480
 
-          vulnerability-check: true
-          fail-on-severity: moderate
-          show-patched-versions: true
+          vulnerability-check: false
 
           license-check: true
           # comma-separated SPDX identifiers


### PR DESCRIPTION
We've migrated PR-time dependency vulnerability checks to Socket.